### PR TITLE
Added ctype extension

### DIFF
--- a/5.5.1/Dockerfile
+++ b/5.5.1/Dockerfile
@@ -1,0 +1,50 @@
+# PHPUnit Docker Container.
+FROM alpine:edge
+MAINTAINER Julien Breux <julien.breux@gmail.com>
+
+RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing add \
+        bash \
+        ca-certificates \
+        git \
+        curl \
+        unzip \
+        php7 \
+        php7-xml \
+        php7-zip \
+        php7-xmlreader \
+        php7-zlib \
+        php7-opcache \
+        php7-mcrypt \
+        php7-openssl \
+        php7-curl \
+        php7-json \
+        php7-dom \
+        php7-phar \
+        php7-mbstring \
+        php7-bcmath \
+        php7-pdo \
+        php7-pdo_pgsql \
+        php7-pdo_sqlite \
+        php7-pdo_mysql \
+        php7-soap \
+        php7-xdebug \
+        php7-pcntl \ 
+        php7-ctype
+
+RUN ln -s /usr/bin/php7 /usr/bin/php
+
+WORKDIR /tmp
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');" \
+    && composer require "phpunit/phpunit:~5.5.0" --prefer-source --no-interaction \
+    && composer require "phpunit/php-invoker" --prefer-source --no-interaction \
+    && ln -s /tmp/vendor/bin/phpunit /usr/local/bin/phpunit \
+    && sed -i 's/nn and/nn, Julien Breux (Docker) and/g' /tmp/vendor/phpunit/phpunit/src/Runner/Version.php
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]


### PR DESCRIPTION
Hi there,

I'm using the latest `phpunit/phpunit` image to run some tests for a Laravel app on BitBucket Pipelines, however I get each test fatal error-ing with the following message:

```bash
Error: Call to undefined function Illuminate\Support\ctype_lower()
```

I believe this is due to the `ctype` extension not being present in [these bits of code](https://github.com/laravel/framework/search?utf8=%E2%9C%93&q=ctype) which is causing the fatal errors I mentioned.

Could this be added to the Dockerfile?