### PR TITLE
Make rake work on case-sensitive OS

### DIFF
--- a/scripts/Template.rb
+++ b/scripts/Template.rb
@@ -1,5 +1,5 @@
 require 'liquid'
-require_relative 'settings'
+require_relative 'Settings'
 
 # Template manager
 module Template


### PR DESCRIPTION
`rake -T` on Linux gives this error:

```
rake aborted!
LoadError: cannot load such file -- /home/leon/src/LeonB/phpunit-docker/scripts/settings
/home/leon/src/LeonB/phpunit-docker/scripts/Template.rb:2:in `require_relative'
/home/leon/src/LeonB/phpunit-docker/scripts/Template.rb:2:in `<top (required)>'
/home/leon/src/LeonB/phpunit-docker/Rakefile:5:in `require'
/home/leon/src/LeonB/phpunit-docker/Rakefile:5:in `<top (required)>'
/home/leon/.rbenv/versions/2.3.0/bin/bundle:23:in `load'
/home/leon/.rbenv/versions/2.3.0/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

This pull requests fixes that.