### PR TITLE
Set default base image to alpine:3.7 and improved Dockerfile

### DIFF
--- a/6.5.2/Dockerfile
+++ b/6.5.2/Dockerfile
@@ -1,6 +1,6 @@
 # PHPUnit Docker Container.
-FROM alpine:latest
-MAINTAINER Julien Breux <julien.breux@gmail.com>
+FROM alpine:3.7
+LABEL mantainer="Julien Breux <julien.breux@gmail.com>"
 
 ENV PEAR_PACKAGES foo
 
@@ -9,35 +9,35 @@ WORKDIR /tmp
 RUN apk --no-cache add \
         bash \
         ca-certificates \
-        git \
         curl \
-        unzip \
+        git \
         php7 \
-        php7-xml \
-        php7-exif \
-        php7-zip \
-        php7-xmlreader \
-        php7-zlib \
-        php7-opcache \
-        php7-mcrypt \
-        php7-openssl \
-        php7-curl \
-        php7-json \
-        php7-dom \
-        php7-phar \
-        php7-mbstring \
         php7-bcmath \
+        php7-ctype \
+        php7-curl \
+        php7-dom \
+        php7-exif \
+        php7-json \
+        php7-mbstring \
+        php7-mcrypt \
+        php7-opcache \
+        php7-openssl \
+        php7-pcntl \
         php7-pdo \
+        php7-pdo_mysql \
         php7-pdo_pgsql \
         php7-pdo_sqlite \
-        php7-pdo_mysql \
-        php7-soap \
-        php7-xdebug \
-        php7-pcntl \
-        php7-ctype \
+        php7-phar \
         php7-session \
+        php7-soap \
         php7-tokenizer \
+        php7-xdebug \
+        php7-xml \
+        php7-xmlreader \
         php7-xmlwriter \
+        php7-zip \
+        php7-zlib \
+        unzip \
     && php -r "copy('https://pear.php.net/go-pear.phar', 'go-pear.phar');" \
     && php go-pear.phar \
     && php -r "unlink('go-pear.phar');" \
@@ -48,12 +48,14 @@ RUN apk --no-cache add \
     && composer require "phpunit/php-invoker" --prefer-source --no-interaction \
     && ln -s /tmp/vendor/bin/phpunit /usr/local/bin/phpunit \
     && sed -i 's/nn and/nn, Julien Breux (Docker) and/g' /tmp/vendor/phpunit/phpunit/src/Runner/Version.php \
-
     # Enable X-Debug
     && sed -i 's/\;z/z/g' /etc/php7/conf.d/xdebug.ini \
     && php -m | grep -i xdebug
 
-ONBUILD RUN [ $PEAR_PACKAGES != "foo" ] || exit 0 && pear install $PEAR_PACKAGES
+ONBUILD RUN \
+    { \
+        [ "${PEAR_PACKAGES}" != "foo" ] \
+    } || exit 0 && pear install ${PEAR_PACKAGES}
 
 VOLUME ["/app"]
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 2. Create a phpunit.xml defining your tests suites.
 
     ``` xml
-...
+    ...
     ```
 
 3. Run PHPUnit through the PHPUnit container:

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,6 +1,6 @@
 # PHPUnit Docker Container.
-FROM alpine:latest
-MAINTAINER Julien Breux <julien.breux@gmail.com>
+FROM alpine:3.7
+LABEL mantainer="Julien Breux <julien.breux@gmail.com>"
 
 ENV PEAR_PACKAGES foo
 
@@ -9,34 +9,35 @@ WORKDIR /tmp
 RUN apk --no-cache add \
         bash \
         ca-certificates \
-        git \
         curl \
-        unzip \
+        git \
         php7 \
-        php7-xml \
-        php7-exif \
-        php7-zip \
-        php7-xmlreader \
-        php7-zlib \
-        php7-opcache \
-        php7-mcrypt \
-        php7-openssl \
-        php7-curl \
-        php7-json \
-        php7-dom \
-        php7-phar \
-        php7-mbstring \
         php7-bcmath \
+        php7-ctype \
+        php7-curl \
+        php7-dom \
+        php7-exif \
+        php7-json \
+        php7-mbstring \
+        php7-mcrypt \
+        php7-opcache \
+        php7-openssl \
+        php7-pcntl \
         php7-pdo \
+        php7-pdo_mysql \
         php7-pdo_pgsql \
         php7-pdo_sqlite \
-        php7-pdo_mysql \
-        php7-soap \
-        php7-xdebug \
-        php7-pcntl \
-        php7-ctype \
+        php7-phar \
         php7-session \
+        php7-soap \
         php7-tokenizer \
+        php7-xdebug \
+        php7-xml \
+        php7-xmlreader \
+        php7-xmlwriter \
+        php7-zip \
+        php7-zlib \
+        unzip \
     && php -r "copy('https://pear.php.net/go-pear.phar', 'go-pear.phar');" \
     && php go-pear.phar \
     && php -r "unlink('go-pear.phar');" \
@@ -47,12 +48,14 @@ RUN apk --no-cache add \
     && composer require "phpunit/php-invoker" --prefer-source --no-interaction \
     && ln -s /tmp/vendor/bin/phpunit /usr/local/bin/phpunit \
     && sed -i 's/nn and/nn, Julien Breux (Docker) and/g' /tmp/vendor/phpunit/phpunit/src/Runner/Version.php \
-
     # Enable X-Debug
     && sed -i 's/\;z/z/g' /etc/php7/conf.d/xdebug.ini \
     && php -m | grep -i xdebug
 
-ONBUILD RUN [ $PEAR_PACKAGES != "foo" ] || exit 0 && pear install $PEAR_PACKAGES
+ONBUILD RUN \
+    { \
+        [ "${PEAR_PACKAGES}" != "foo" ] \
+    } || exit 0 && pear install ${PEAR_PACKAGES}
 
 VOLUME ["/app"]
 WORKDIR /app

--- a/settings.yml
+++ b/settings.yml
@@ -8,7 +8,7 @@ project:
     name: Julien Breux
     email: julien.breux@gmail.com
 image:
-  base: alpine:latest
+  base: alpine:3.7
 php:
   version: 7.0
 versions:

--- a/templates/Dockerfile.liquid
+++ b/templates/Dockerfile.liquid
@@ -1,6 +1,6 @@
 # {{ project.name }} Docker Container.
 FROM {{ image.base }}
-MAINTAINER {{ project.author.name }} <{{ project.author.email }}>
+LABEL mantainer="{{ project.author.name }} <{{ project.author.email }}>"
 
 ENV PEAR_PACKAGES foo
 
@@ -9,34 +9,35 @@ WORKDIR /tmp
 RUN apk --no-cache add \
         bash \
         ca-certificates \
-        git \
         curl \
-        unzip \
+        git \
         php7 \
-        php7-xml \
-        php7-exif \
-        php7-zip \
-        php7-xmlreader \
-        php7-zlib \
-        php7-opcache \
-        php7-mcrypt \
-        php7-openssl \
-        php7-curl \
-        php7-json \
-        php7-dom \
-        php7-phar \
-        php7-mbstring \
         php7-bcmath \
+        php7-ctype \
+        php7-curl \
+        php7-dom \
+        php7-exif \
+        php7-json \
+        php7-mbstring \
+        php7-mcrypt \
+        php7-opcache \
+        php7-openssl \
+        php7-pcntl \
         php7-pdo \
+        php7-pdo_mysql \
         php7-pdo_pgsql \
         php7-pdo_sqlite \
-        php7-pdo_mysql \
-        php7-soap \
-        php7-xdebug \
-        php7-pcntl \
-        php7-ctype \
+        php7-phar \
         php7-session \
+        php7-soap \
         php7-tokenizer \
+        php7-xdebug \
+        php7-xml \
+        php7-xmlreader \
+        php7-xmlwriter \
+        php7-zip \
+        php7-zlib \
+        unzip \
     && php -r "copy('https://pear.php.net/go-pear.phar', 'go-pear.phar');" \
     && php go-pear.phar \
     && php -r "unlink('go-pear.phar');" \
@@ -47,12 +48,14 @@ RUN apk --no-cache add \
     && composer require "phpunit/php-invoker" --prefer-source --no-interaction \
     && ln -s /tmp/vendor/bin/{{ project.code_name }} /usr/local/bin/{{ project.code_name }} \
     && sed -i 's/nn and/nn, {{ project.author.name }} (Docker) and/g' /tmp/vendor/phpunit/phpunit/src/Runner/Version.php \
-
     # Enable X-Debug
     && sed -i 's/\;z/z/g' /etc/php7/conf.d/xdebug.ini \
     && php -m | grep -i xdebug
 
-ONBUILD RUN [ $PEAR_PACKAGES != "foo" ] || exit 0 && pear install $PEAR_PACKAGES
+ONBUILD RUN \
+    { \
+        [ "${PEAR_PACKAGES}" != "foo" ] \
+    } || exit 0 && pear install ${PEAR_PACKAGES}
 
 VOLUME ["/app"]
 WORKDIR /app

--- a/templates/README.md.liquid
+++ b/templates/README.md.liquid
@@ -23,7 +23,7 @@
 2. Create a {{ project.code_name }}.xml defining your tests suites.
 
     ``` xml
-...
+    ...
     ```
 
 3. Run {{ project.name }} through the {{ project.name }} container:


### PR DESCRIPTION
The base image should be fixed to a specific one, otherwise, with time, it will be impossible to recreate/modify/build this project if the base image changes substantially. For example, at work I'm using version 4.8.5 which has composer/composer as base image and I cannot recreate / modify it, as the actual composer/composer image runs php 7 while the 4.8.5 still runs php 5.5 and docker build fails.
I have also updated the rest of the Dockerfile for master and 6.5.2 to match the latest best practices of Dockerfile: MAINTAINER has been changed to LABEL, the packages have been ordered alphabetically (it is easier to check if a package is missing) and few other improvements.
I have also modified the templates, so that the next versions will keep this format.
Regards
Fabio